### PR TITLE
Add undo/redo functions to Widgets

### DIFF
--- a/MiniRemoto/Widgets/ImageWidget/ImageWidgetView.swift
+++ b/MiniRemoto/Widgets/ImageWidget/ImageWidgetView.swift
@@ -9,11 +9,11 @@
 import Foundation
 import UIKit
 
-/// A representation of an Image Widget. This WidgetView
+/// A representation of an `ImageWidget`. This `WidgetView`
 /// should only be instantiated when being added to a Canvas.
 final class ImageWidgetView: WidgetView {
-    /// The UIImageView used to display this ImageWidget's image.
-    /// This UIImageView will fill the entirety of this ImageWidget's frame.
+    /// The UIImageView used to display a `ImageWidget`'s image.
+    /// This UIImageView will fill the entirety of a `ImageWidget`'s frame.
     @AutoLayout private var imageView: UIImageView
 
     /// The image being displayed. It is assumed that
@@ -36,7 +36,7 @@ final class ImageWidgetView: WidgetView {
         setupUI()
     }
 
-    /// Set the UI up with constraints to match this ImageWidget's frame.
+    /// Set the UI up with constraints to match a `ImageWidget`'s frame.
     private func setupUI() {
         view.backgroundColor = .systemBackground
 
@@ -51,5 +51,34 @@ final class ImageWidgetView: WidgetView {
              imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
              imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor)]
         )
+    }
+
+    /// Updates a `ImageWidget`'s image with the `UIImage` passed as the parameter.
+    /// It also registers a new undo operation in the `UndoManager`. Updating of a
+    /// `ImageWidget`'s image should be done through this function to maintain the correct
+    /// order of operations in the `UndoManager`.
+    /// - parameter image: The new image to be set.
+    func updateImage(_ image: UIImage) {
+        let currentImage = self.image
+        self.image = image
+        self.imageView.image = image
+
+        undoManager?.registerUndo(withTarget: self, handler: { (target) in
+            target.updateImage(currentImage)
+        })
+    }
+
+    func undo() {
+        guard let undoManager = undoManager else { return }
+        if undoManager.canUndo {
+            undoManager.undo()
+        }
+    }
+
+    func redo() {
+        guard let undoManager = undoManager else { return }
+        if undoManager.canRedo {
+            undoManager.redo()
+        }
     }
 }

--- a/MiniRemoto/Widgets/TextWidget/TextWidgetController.swift
+++ b/MiniRemoto/Widgets/TextWidget/TextWidgetController.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-/// A Controller to a TextWidgetView. It should provide the
-/// TextWidgetView with input validation, if necessary.
+/// A Controller to a `TextWidgetView`. It should provide the
+/// `TextWidgetView` with input validation, if necessary.
 final class TextWidgetController {
     /// The Model used to hold the data from the user's input.
     private var model: TextWidgetModel
 
     /// Initialise a new instance of this type.
-    /// If no TextWidgetModel is provied during the instantiaton process,
-    /// a new TextWidgetModel will be created with empty `title` and `body`.
+    /// If no `TextWidgetModel` is provied during the instantiaton process,
+    /// a new `TextWidgetModel` will be created with empty `title` and `body`.
     /// - parameter model: The Model used to hold the data from the user's input.
     init(model: TextWidgetModel? = nil) {
         if let model = model {

--- a/MiniRemoto/Widgets/TextWidget/TextWidgetModel.swift
+++ b/MiniRemoto/Widgets/TextWidget/TextWidgetModel.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreData
 
-/// The Model used by the TextWidget's Controller.
+/// The Model used by the `TextWidget`'s Controller.
 struct TextWidgetModel {
     /// The title input from the user.
     var title: String

--- a/MiniRemoto/Widgets/TextWidget/TextWidgetView.swift
+++ b/MiniRemoto/Widgets/TextWidget/TextWidgetView.swift
@@ -9,12 +9,12 @@
 import Foundation
 import UIKit
 
-/// A representation of a TextWidgetView. This WidgetView
+/// A representation of a `TextWidgetView`. This `WidgetView`
 /// should only be instantiated when being added to a Canvas.
 final class TextWidgetView: WidgetView {
-    /// The representation of this TextWidget's title.
+    /// The representation of a `TextWidget`'s title.
     @AutoLayout private var titleTextField: UITextField
-    /// The representation of this TextWidget's body.
+    /// The representation of a `TextWidget`'s body.
     @AutoLayout private var bodyTextView: UITextView
 
     /// The Controller used by this type.
@@ -38,7 +38,7 @@ final class TextWidgetView: WidgetView {
     }
 
     /// Set the UI up with constraints so `titleTextField` and `bodyTextView`
-    /// occupy 15% and 85% of this TextWidget's frame, respectively.
+    /// occupy 15% and 85% of a `TextWidget`'s frame, respectively.
     /// Configures `titleTextField` and `bodyTextView`.
     private func setupUI() {
         view.backgroundColor = .systemBackground
@@ -68,22 +68,61 @@ final class TextWidgetView: WidgetView {
              bodyTextView.topAnchor.constraint(equalTo: titleTextField.bottomAnchor)]
         )
     }
+
+    func undo() {
+        guard let undoManager = undoManager else { return }
+        if undoManager.canUndo {
+            undoManager.undo()
+        }
+    }
+
+    func redo() {
+        guard let undoManager = undoManager else { return }
+        if undoManager.canRedo {
+            undoManager.redo()
+        }
+    }
 }
 
 extension TextWidgetView: UITextViewDelegate {
     /// Sends the current `bodyTextView`'s text to
     /// the Controller's body variable when the user ends
-    /// their editing.
+    /// their editing. Functions as a passthrough function
+    /// to enable safe recording of the operation.
     func textViewDidEndEditing(_ textView: UITextView) {
-        controller.body = bodyTextView.text
+        updateBody(textView.text)
+    }
+
+    /// Updates the body of a `TextWidget`. Records the operation
+    /// using `UndoManager` to allow undo and redo.
+    private func updateBody(_ text: String) {
+        let currentText = controller.body
+        controller.body = text
+
+        undoManager?.registerUndo(withTarget: self, handler: { (target) in
+            target.updateBody(currentText)
+        })
     }
 }
 
 extension TextWidgetView: UITextFieldDelegate {
     /// Sends the current `titleTextField`'s text to
     /// the Controller's title variable when the user ends
-    /// their editing.
+    /// their editing. Functions as a passthrough function
+    /// to enable safe recording of the operation.
     func textFieldDidEndEditing(_ textField: UITextField) {
-        controller.title = titleTextField.text ?? ""
+        guard let text = textField.text else { return }
+        updateTitle(text)
+    }
+
+    /// Updates the title of a `TextWidget`. Records the operation
+    /// using `UndoManager` to allow undo and redo.
+    private func updateTitle(_ text: String) {
+        let currentText = controller.body
+        controller.title = text
+
+        undoManager?.registerUndo(withTarget: self, handler: { (target) in
+            target.updateTitle(currentText)
+        })
     }
 }


### PR DESCRIPTION
Some of the functions may need to be changed depending on how
we opt to call the function responsible for opening the image
gallery. If we opted to have this function be called from outside
the `ImageWidget`, the current code is fine. However, if we
opt for the opposite than we need to repurpose the current
function responsible for updating a `ImageWidget` image.